### PR TITLE
handle artifacts with ".pom" in artifactId

### DIFF
--- a/share/maven-debian-helper/copy-repo.sh
+++ b/share/maven-debian-helper/copy-repo.sh
@@ -22,7 +22,7 @@ PLUGIN_GROUPS="org.apache.maven.plugins org.codehaus.mojo org.codehaus.plexus or
 METADATA_NAME="maven-metadata-local.xml"
 
 find_src_poms() {
-  find -L $SRC_REPO -name '*.pom' -printf '%P\n'
+  find -L $SRC_REPO -type f -name '*.pom' -printf '%P\n'
 }
 
 find_group_artifact_ids() {


### PR DESCRIPTION
This should not happen... anyway it happens:
http://mvnrepository.com/artifact/org.ow2.sat4j/org.ow2.sat4j.pom
